### PR TITLE
Setup stbiw library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-#add_subdirectory(stbiw)
+add_subdirectory(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
-#target_link_libraries(main PUBLIC stbiw)
+target_link_libraries(main PUBLIC stbiw)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbiw)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stbiw.cpp
+++ b/stbiw/stbiw.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
stbi 是一个头文件库，函数的实现也是在头文件中的，如果不用一个开关控制一下，那么每个 #include 的文件里面都会有相同的实现内容，编译之后生成的obj文件链接的时候会有多重定义的问题。所以只能在一个cpp文件中有函数的实现，其他文件只能是声明，这个#define就是干这个的。