### PR TITLE
finish hw01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 GNUmakefile
+CMakeFiles
+CMakeCache.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 build
 GNUmakefile
-CMakeFiles
-CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,4 @@ add_subdirectory(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
 target_link_libraries(main PUBLIC stbiw)
+target_include_directories(main PUBLIC stbiw)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,3 @@ add_subdirectory(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
 target_link_libraries(main PUBLIC stbiw)
-target_include_directories(main PUBLIC stbiw)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,1 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbiw.cpp)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(stbiw STATIC stbiw.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stbiw.cpp
+++ b/stbiw/stbiw.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
`stbiw.cpp` 里面先 define 了 STB_IMAGE_WRITE_IMPLEMENTATION 再 include "stb_image_write.h" 预处理器会把里面实现的部分粘贴到这个文件里面，这个文件就变成了它的实现代码。但是外面的文件 include 的时候它没定义那个宏，就只粘贴声明部分，不会粘贴实现部分。stb 通过这种机制就可以把声明和实现放在一个文件里面，方便使用，一复制一粘贴过来就能用了。