### PR TITLE
hw01 solution

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,5 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+
+aux_source_directory(. DIR_STBIW)
+add_library(stbiw STATIC ${DIR_STBIW})
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,3 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+
+#include "stb_image_write.h"


### PR DESCRIPTION
我只试了Linux下的编译。
定义`STB_IMAGE_WRITE_IMPLEMENTATION`宏的原因：
相关函数的声明、定义都放在了`stb_image_write.h`文件中，所以有多个文件都`include`了头文件的时候会有重复定义的问题。

请教一个问题：
如果`.h`文件写声明，`.cpp`文件写定义的话，`include`语句放在哪个文件比较好？