### PR TITLE
why?

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(stbiw STATIC stb_image_write.cpp)
 target_include_directories(stbiw PUBLIC .)
-add_compile_definitions(STB_IMAGE_WRITE_IMPLEMENTATION)
+
+# add_compile_definitions(STB_IMAGE_WRITE_IMPLEMENTATION)
+target_compile_definitions(stbiw PRIVATE STB_IMAGE_WRITE_IMPLEMENTATION)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_library(stbiw STATIC stb_image_write.cpp)
 target_include_directories(stbiw PUBLIC .)
+add_compile_definitions(STB_IMAGE_WRITE_IMPLEMENTATION)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,2 +1,2 @@
-#define STB_IMAGE_WRITE_IMPLEMENTATION
+// #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>


### PR DESCRIPTION
之前提交过一次作业了~

但是后来发现在 `stbiw/stb_image_write.cpp` 不添加 
```
#define STB_IMAGE_WRITE_IMPLEMENTATION
```
而是在 `stbiw/CMakeLists.txt` 中添加 
```
add_compile_definitions(STB_IMAGE_WRITE_IMPLEMENTATION)
``` 
或  
```
target_compile_definitions(stbiw PRIVATE STB_IMAGE_WRITE_IMPLEMENTATION)
```
也可以成功运行，这三者有什么区别呢？

将 `target_compile_definitions` 中的 `PRIVATE` 改为 `PUBLIC` 却不行，这又是为什么？
