### PR TITLE
hw01/子模块+库

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define  STB_IMAGE_WRITE_IMPLEMENTATION
+#include"stb_image_write.h"


### PR DESCRIPTION
1. /hw01/stbiw/下创建`stb_image_write.cpp`，定义宏名后再`inculde"stb_image_write.h"`，这样只会编译stbi中实现write的部分.
2. 修改/hw01/stbiw/CMakeLists.txt，使用`add_library`创建静态库，再使用`target_include_directories`定义stbiw的头文件搜索目录为当前路径.