### PR TITLE
finish

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
`#define STB_IMAGE_WRITE_IMPLEMENTATION`，这样函数在多次引用时只会定义一遍
`target_include_directories(stbiw PUBLIC .)` 是为了外部能够搜索到这个库，不然就只有在外面的CMakeList里写相关的`target_include_directories`。

另外请问老师要调用`stb_image_write.h`一定要创建一个对应的cpp文件吗，有没有直接引这个库的方法？也就是说，能不能通过类似`add_library(stbiw STATIC stb_image_write.h)`的方法来直接调用？(这个好像不行)

