### PR TITLE
[Question] why is it necessary to have another cpp file to include the header?

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,4 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw stb_image_write.h)
+set_target_properties(stbiw PROPERTIES LINKER_LANGUAGE CXX)
+target_compile_definitions(stbiw PRIVATE STB_IMAGE_WRITE_IMPLEMENTATION)
+target_include_directories(stbiw PUBLIC .)


### PR DESCRIPTION
我按照stbiw的doc加入一个.cpp文件，然后只在那里定义来生成implementation，结果是成功的。
但是有洁癖的我很奇怪为什么必须有一个新的cpp？我提交的这样不添加.cpp，直接使用.h可以编译，但在链接时会提示找不到stbiw的函数，可是明明链接了stbiw.a了啊

报错如下
<details>
<summary> cmake verbose的输出 </summary>

```
Scanning dependencies of target stbiw
make[2]: Leaving directory '/home/alexfan/Documents/parallel101/build'
/usr/bin/make -f stbiw/CMakeFiles/stbiw.dir/build.make stbiw/CMakeFiles/stbiw.dir/build
make[2]: Entering directory '/home/alexfan/Documents/parallel101/build'
[ 20%] Linking CXX static library libstbiw.a
cd /home/alexfan/Documents/parallel101/build/stbiw && /usr/bin/cmake -P CMakeFiles/stbiw.dir/cmake_clean_target.cmake
cd /home/alexfan/Documents/parallel101/build/stbiw && /usr/bin/cmake -E cmake_link_script CMakeFiles/stbiw.dir/link.txt --verbose=1
/usr/bin/ar qc libstbiw.a  
/usr/bin/ranlib libstbiw.a
make[2]: Leaving directory '/home/alexfan/Documents/parallel101/build'
[ 20%] Built target stbiw
/usr/bin/make -f CMakeFiles/main.dir/build.make CMakeFiles/main.dir/depend
make[2]: Entering directory '/home/alexfan/Documents/parallel101/build'
cd /home/alexfan/Documents/parallel101/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /home/alexfan/Documents/parallel101/hw01 /home/alexfan/Documents/parallel101/hw01 /home/alexfan/Documents/parallel101/build /home/alexfan/Documents/parallel101/build /home/alexfan/Documents/parallel101/build/CMakeFiles/main.dir/DependInfo.cmake --color=
Dependee "/home/alexfan/Documents/parallel101/build/CMakeFiles/main.dir/DependInfo.cmake" is newer than depender "/home/alexfan/Documents/parallel101/build/CMakeFiles/main.dir/depend.internal".
Dependee "/home/alexfan/Documents/parallel101/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/alexfan/Documents/parallel101/build/CMakeFiles/main.dir/depend.internal".
Scanning dependencies of target main
make[2]: Leaving directory '/home/alexfan/Documents/parallel101/build'
/usr/bin/make -f CMakeFiles/main.dir/build.make CMakeFiles/main.dir/build
make[2]: Entering directory '/home/alexfan/Documents/parallel101/build'
[ 40%] Building CXX object CMakeFiles/main.dir/main.cpp.o
/usr/bin/c++   -I/home/alexfan/Documents/parallel101/hw01/stbiw/.  -O3 -DNDEBUG   -o CMakeFiles/main.dir/main.cpp.o -c /home/alexfan/Documents/parallel101/hw01/main.cpp
[ 60%] Building CXX object CMakeFiles/main.dir/rainbow.cpp.o
/usr/bin/c++   -I/home/alexfan/Documents/parallel101/hw01/stbiw/.  -O3 -DNDEBUG   -o CMakeFiles/main.dir/rainbow.cpp.o -c /home/alexfan/Documents/parallel101/hw01/rainbow.cpp
[ 80%] Building CXX object CMakeFiles/main.dir/mandel.cpp.o
/usr/bin/c++   -I/home/alexfan/Documents/parallel101/hw01/stbiw/.  -O3 -DNDEBUG   -o CMakeFiles/main.dir/mandel.cpp.o -c /home/alexfan/Documents/parallel101/hw01/mandel.cpp
[100%] Linking CXX executable main
/usr/bin/cmake -E cmake_link_script CMakeFiles/main.dir/link.txt --verbose=1
/usr/bin/c++  -O3 -DNDEBUG   CMakeFiles/main.dir/main.cpp.o CMakeFiles/main.dir/rainbow.cpp.o CMakeFiles/main.dir/mandel.cpp.o  -o main  stbiw/libstbiw.a 
/usr/bin/ld: CMakeFiles/main.dir/rainbow.cpp.o: in function `test_rainbow()':
rainbow.cpp:(.text+0x80): undefined reference to `stbi_write_png'
/usr/bin/ld: CMakeFiles/main.dir/mandel.cpp.o: in function `test_mandel()':
mandel.cpp:(.text+0x137): undefined reference to `stbi_write_png'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/main.dir/build.make:118: main] Error 1
make[2]: Leaving directory '/home/alexfan/Documents/parallel101/build'
make[1]: *** [CMakeFiles/Makefile2:99: CMakeFiles/main.dir/all] Error 2
make[1]: Leaving directory '/home/alexfan/Documents/parallel101/build'
make: *** [Makefile:87: all] Error 2
```

</details>