### PR TITLE
HW1 Submission

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbi_write_png.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stbi_write_png.cpp
+++ b/stbiw/stbi_write_png.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
首先谢谢小彭老师为大家提供这么好的课。

为什么stbi必须要这么设计：
引理1:只有当STB_IMAGE_WRITE_IMPLEMENTATION被定义的时候，stbi的函数body才会被定义
引理2:在我们的作业中，STB_IMAGE_WRITE_IMPLEMENTATION只被定义了一次。

于是根据引理1、2，stbi的函数只会被implement一次，避免了多次定义的混乱。而且注意到无论有没有define STB_IMAGE_WRITE_IMPLEMENTATION，stbi的函数签名都会被加入include了stb头文件的cpp文件里，所以编译器可以清晰的知道上下文信息。


如果不加入STB_IMAGE_WRITE_IMPLEMENTATION这个开关，请考虑下述情况。
a.cpp和b.cpp都include了stb_image_write.h. 同时，a.cpp还引用了b.a(b.cpp的静态库)。这样一来，a.cpp就包含了两份stbi的函数声明，编译将无法通过。

烦请小彭老师指教：）