### PR TITLE
homework1

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_STATIC
+#include "stb_image_write.h"

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,2 +1,2 @@
-#define STB_IMAGE_WRITE_STATIC
+#define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"


### PR DESCRIPTION
抱歉作业迟交了～

为什么 stbi 必须要这样设计？
* easy to distribute and deploy
* Windows doesn't have standard directories to deploy library. Single-file headers make it less painful to deploy a library in Windows.