### PR TITLE
add static library for stbiw

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
stbi设计需要定义` STB_IMAGE_WRITE_IMPLEMENTATION `的原因是h文件中包含了一系列的声明在`INCLUDE_STB_IMAGE_WRITE_H`内部，具体的实现在`STB_IMAGE_WRITE_IMPLEMENTATION `内部，由于该h文件会被多次包含，为了防止具体的实现重复出现多次，就需要将实现包含在`STB_IMAGE_WRITE_IMPLEMENTATION `内部。

通过引入头文件前定义一次该宏，可以保证如果多个C++翻译单元都引用了该h文件，链接这些翻译单元时具体的实现也不会出现重复定义。