### PR TITLE
add stb_image_write.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_subdirectory(stbiw)
+include_directories(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
 target_link_libraries(main PUBLIC stbiw)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,1 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw stb_image_write.cpp)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
添加stb_image_write.cpp，并在include stb_image_write.h之前添加STB_IMAGE_WRITE_IMPLEMENTATION宏定义，完成条件编译。在使用头文件库的时候，可能会在每一个引用的cpp都编译出一份函数的字节码，stb的这个机制可以避免这种情况。