### PR TITLE
HW1 Submission

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,4 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+project(stbiw)
+
+add_library(stbiw SHARED lib.cpp)
+target_include_directories(stbiw PUBLIC "${STBIW_INCLUDE_DIR}")

--- a/stbiw/lib.cpp
+++ b/stbiw/lib.cpp
@@ -1,0 +1,5 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#ifdef _WIN32
+#define STBIWDEF extern "C" __declspec(dllexport)
+#endif
+#include "stb_image_write.h"


### PR DESCRIPTION
Tested on Windows MSVC and WSL MINGW.
Hacked STBIWDEF to work on windows.

为什么要设计STB_IMAGE_WRITE_IMPLEMENTATION?
理论上需要区分定义和实现，但是sbt是header-only的库，因此需要这个开关来区分定义和实现，使得实现有且仅有一个。