### PR TITLE
01

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.2)
 project(hellocmake LANGUAGES CXX)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp) #生成stbiw静态库
+target_include_directories(stbiw PUBLIC .)#定义stbiw的搜索路径为当前路径

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
利用add_library生成库，但由于库在另外一个目录下,一种可以修改main.cpp文件中包含头文件的路径，一种是利用target_include_directories定义库的搜索路径，这样更加方便，其他文件要使用该库的时候就不用在源文件中修改