### PR TITLE
hw01

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbiw.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stbiw.cpp
+++ b/stbiw/stbiw.cpp
@@ -1,0 +1,3 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include"stb_image_write.h"
+


### PR DESCRIPTION
stbiw之所以这么设计是因为，如果不涉及这个宏的话，一个文件的两个头文件同时引用这个头文件这种菱形引用就会导致头文件中的实现只有一份，导致其中一个头文件中的实现部分什么都没引而出问题。