### PR TITLE
submit hw01:SHAED cant work in win,STATIC works in two env

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,4 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbiw.cpp)
+#set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+target_include_directories(stbiw PUBLIC .)
+#message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")

--- a/stbiw/stbiw.cpp
+++ b/stbiw/stbiw.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
1. SHARED在win下好像并不能很好的运行，win下默认不会把 DLL 的所有符号导出。注释掉的部分不知道是不是正解，尝试了没有成功。
2. 这种设计其实在stb的readme中已经写了， 主要就是为了分发和部署，所有的代码都包含在一个头文件中。但他们不会导致任何代码被编译。
3. 因此，需要选择一个实例化的源文件，定义一个宏来开启函数定义。定义只可以在一个文件里出现一次，而声明可以在多个文件出现
```
#define STB_IMAGE_IMPLEMENTATION
#include "stb_image.h"
```

cmake -B build