### PR TITLE
hw01作业

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,4 @@ add_subdirectory(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
 target_link_libraries(main PUBLIC stbiw)
+target_include_directories(main PUBLIC stbiw)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,3 @@ add_subdirectory(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
 target_link_libraries(main PUBLIC stbiw)
-target_include_directories(main PUBLIC stbiw)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,1 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION 
+#include "stb_image_write.h"


### PR DESCRIPTION
通过 target_include_directories 指定的路径会被视为与系统路径等价， 所以可以用 <stb_image_write.h> 来引用这个头文件了
## 如果把指定路径的修饰符PUBLIC改为Private就报错， 还不明白为啥 :(