### PR TITLE
HW1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 GNUmakefile
+
+.vscode

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,2 +1,2 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
-#include "stb_image_write.h"
+#include <stb_image_write.h>


### PR DESCRIPTION
# HW1 Report

## 步骤
1. 在stbiw中添加stb_image_write.cpp文件，include对应头文件并添加开关宏。
2. 在CMakeLists.txt中添加stbiw的静态库，并指定stbiw的include路径。
   
## 解释

1. 编译时以cpp文件为单位进行编译，只有头文件无法编译，所以需要在stbiw中添加对应的.cpp文件以编译静态库。
2. stb_image_write.h的内容大致为:
    ```cpp
    #ifndef INCLUDE_STB_IMAGE_WRITE_H
    //声明
    #endif

    #ifdef STB_IMAGE_WRITE_IMPLEMENTATION
    //定义
    #endif
    ```
    所以需要添加STB_IMAGE_WRITE_IMPLEMENTATION来开启对应部分的实现。由于实现部分并没有类似的头文件保护，如果多处添加该宏就会重定义。