### PR TITLE
hw1

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,4 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include"stb_image_write.h"


### PR DESCRIPTION
为什么stbi要这样设计
首先我理解的“这样”指的是header only，且当引用时需要定义一个STB_IMAGE_WRITE_IMPLEMENTATION这样的宏。
header only的好处是跨平台+使用方便，为了实现header only就需要把函数实现写在头文件中，但是为了避免多次定义，就需要加入STB_IMAGE_WRITE_IMPLEMENTATION这样的宏。