### PR TITLE
Finish hw01

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(stbiw stb_image_write.cpp)
+add_library(stbiw SHARED stb_image_write.cpp)
 
 target_compile_definitions(stbiw PRIVATE STB_IMAGE_WRITE_IMPLEMENTATION)
 target_include_directories(stbiw PUBLIC .)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,4 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw stb_image_write.cpp)
+
+target_compile_definitions(stbiw PRIVATE STB_IMAGE_WRITE_IMPLEMENTATION)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,1 @@
+#include <stb_image_write.h>


### PR DESCRIPTION
1. 新建一个.cpp文件，然后只include对应的.h文件
2. 增加lib的编译选项，而且设置为私有的，这是因为如果传播的话，会导致其他依赖.h的文件都会看到实现，则link的时候会有多个符号重复
3. 同时target_include_directories中要设置为PUBLIC，使得其他库可以直接使用include<>

定义了STB_IMAGE_WRITE_IMPLEMENTATION这个宏，可以控制include的文件是只能看到定义还是可以看到实现。从而避免
link的时候出现对个相同符号的问题。