### PR TITLE
hw01 && 尝试解释 stbi 宏定义的设计原因 

### DIFF
--- a/mandel.cpp
+++ b/mandel.cpp
@@ -1,3 +1,5 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+
 #include "mandel.h"
 #include <stb_image_write.h>
 #include <vector>

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,4 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+
+add_library(stbiw INTERFACE)
+target_include_directories(stbiw INTERFACE .)


### PR DESCRIPTION
一些c/cpp的库由头文件和cpp文件组成，头文件中写声明，而cpp文件中写定义。编译时指定头文件路径，并
编译出静态库进行链接（或者运行时动态链接）即可。

另一种cpp库为header only，即只有头文件。但是普通的函数定义不能放在头文件中，因为如果在多个cpp文件
中include这个头文件就会造成ODR violation。为了解决这个问题：
- 只在头文件中定义模板函数、内联函数（比如STL）
- 使用类似`STB_IMAGE_WRITE_IMPLEMENTATION`这样的宏，由这个宏包裹起来的代码为函数的实现，不包裹起来的代码为声明，所以如果我们只在一个cpp文件中定义这个宏，相当于函数的实现就只会出现一次，就不会出现重复定义的问题。


## 方法2

对于stb库，我们也可以把这个头文件中的函数定义部分抽出来放在子模块文件夹里的cpp文件中
```cpp
// stbiw/stb_def.cpp
#define STB_IMAGE_WRITE_IMPLEMENTATION
#include <stb_image_write.h>
```

然后可以在`stbiw/CMakeLists.txt中将stbiw编译成一个静态库
```cmake
add_library(stbiw STATIC stb_def.cpp)
target_include_directories(stbiw PUBLIC .)
```

使用这种方法，我们编译出了一个静态库，只需要链接进main即可，就不需要寻找一个合适的cpp文件把宏定义放进去了

参考：[header only library cmake](http://mariobadr.com/creating-a-header-only-library-with-cmake.html)