### PR TITLE
hw01 finshed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+cmake -H. -Bbuild
+cmake --build ./build
+./build/main

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbiw.cc)
+target_compile_definitions(stbiw PRIVATE -DSTB_IMAGE_WRITE_IMPLEMENTATION)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stbiw.cc
+++ b/stbiw/stbiw.cc
@@ -1,0 +1,1 @@
+#include "stb_image_write.h"


### PR DESCRIPTION
- 当定义`STB_IMAGE_WRITE_IMPLEMENTATION`，`stb_image_write.h`就会添加函数定义，不然只有函数申明。`C++`允许多次申明，所以只要在引用`stb_image_write.h`头文件之前`#define STB_IMAGE_WRITE_IMPLEMENTATION`，后面再使用`stb_image_write.h`的文件不能再定义`STB_IMAGE_WRITE_IMPLEMENTATION`，所以在`./stbiw/CMakeList.txt`的`target_complie_definitions()`中使用`PRIVATE`。
- 因为除`stbiw`静态库中使用`stb_image_write.h`，之后使用`stbiw`库的`main`也要使用。所以在`./stbiw/CMakeList.txt`的`target_include_directories()`中使用`PUBLIC`。
- 添加`stbiw.cc`为了可以生成库。