### PR TITLE
:pencil:hw01

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,7 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+cmake_minimum_required(VERSION 3.12)
+project(stbiw LANGUAGES CXX)
+
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+
+add_library(stbiw SHARED stb_instantiate.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_instantiate.cpp
+++ b/stbiw/stb_instantiate.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>


### PR DESCRIPTION
A文件要用B文件实现的函数，需要在A文件中对函数进行声明
所以为了方便B文件实现的函数被多个别的文件使用，可以将函数的声明和实现分离
需要用到的文件直接include函数的声明即可

stb下的库都是单文件库
为了让声明和实现分离，方便多个文件使用，stb下的库都会约定一个宏`#if define XXXXX`
当这个宏被定义时，后面的函数实现部分才会被编译

题目要求定义stbiw这个库，那么就需要函数的实现，在stdiw文件下新建一个源文件，在include stb_image_write之前define其约定的宏，该源文件就可以在编译时包含声明+实现，从而用该文件生成所需要的库

为了stb_image_write.h能被<>找到，在子目录的cmakelist添加到头文件搜索路径并设为 PUBLIC 即可，这样子目录和主目录的文件都可以通过<> include到stb_image_write.h