### PR TITLE
小彭老师好， hw01

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stbiw.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stbiw.cpp
+++ b/stbiw/stbiw.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include"stb_image_write.h"


### PR DESCRIPTION
## 作业思路
1. 要把 stb_image_write.h 这个头文件 编译成库
2. 因此需要一个 stbiw.cpp 文件作为一个编译单元
3. stbiw.cpp 中要有函数的实现，按照stb_image_write.h使用说明，要先定义宏再include这个头文件
4. stbiw 对应的 CMakeList.txt 中先把 stbiw.cpp 编译成库(add_library), 然后把头文件路径传染给link这个库的其他目标文件(target_include_directories)

## stbi 头文件库这样设计的原因
这个头文件即有函数的声明又有实现，这些声明和实现分别用宏隔离开。
直接include的话，是函数声明
先定义 STB_IMAGE_WRITE_IMPLEMENTATION 宏再include, 是函数实现
优点是使用起来方便，但是每次使用都要重新编译