### PR TITLE
impl stbiw

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw SHARED stb_image_write.cpp)
+target_include_directories(stbiw INTERFACE .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
# header-only 原理
## 1. ```.h``` ```.cpp``` 方式
* hello.h
```cpp
#ifndef __HELLO_H__
#define __HELLO_H__

void sayHello();

#endif // __HELLO_H__
```
* hello.cpp
```cpp
#include "hello.h"
#include <iostream>

void sayHello()
{
  std::cout << "sayHello\n";
}
```
## 2. header-only 方式
```cpp
#ifndef __HELLO_H__
#define __HELLO_H__

#ifndef HELLO_IMPL

void sayHello();

#else

#include <iostream>

void sayHello()
{
  std::cout << "sayHello\n";
}

#endif // HELLO_IMPL

#endif // __HELLO_H__
```
当 ```#define HELLO_IMPL``` 时候，切换声明和定义。
# header-only 用法
* hello.cpp
```cpp
#define HELLO_IMPL
#include "hello.h"
```
* main.cpp
```cpp
#include "hello.h"

int main()
{
  sayHello();
  return 0;
}
```