### PR TITLE
done

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_subdirectory(stbiw)
-
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
 target_link_libraries(main PUBLIC stbiw)
+target_include_directories(main PUBLIC stbiw)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC use.cpp)
+set_target_properties(stbiw PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/use.cpp
+++ b/stbiw/use.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>


### PR DESCRIPTION
遇到重定义问题，知道是头文件重复引入的问题。应该只引入一次即可，但是cmake没有这个编译参数，又不能更改main函数，只能在子模块里改，cpp文件内放入一个宏和include头文件，main函数调用不同头文件，头文件有pragma once，所以只会引入一次lib库文件。mandel和rainbow合并成一个文件就可以避免出现这种情况，
![Tabby_DyRrT2uytn](https://user-images.githubusercontent.com/38826071/166469414-d4f516e0-e244-430c-afce-a0dbed59a4f2.png)
开始困扰我的地方在于我一直以为是只能改cmakelists.txt，但是cmake里面没有课件上写的target_add_definitions函数，最后也是看答案了（😔，结果发现就差一步，太难受了。