### PR TITLE
Finish Homework 1

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -9,3 +9,12 @@ target_include_directories(stbiw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # 设置为 private, 避免宏被传播到所有引用它的文件中, 而导致的重定义错误
 target_compile_definitions(stbiw PRIVATE -DSTB_IMAGE_WRITE_IMPLEMENTATION=1)
+
+# 不能使用 `INTERFACE` 进行编译, 因为 `STB_IMAGE` 里用的是 `#ifdef` 而不是 `#ifndef`
+# add_library(stbiw INTERFACE)
+# target_include_directories(stbiw INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# option(STB_IMAGE_WRITE_IMPLEMENTATION "Enable stb_image_write implementation" OFF)
+# if (NOT ${STB_IMAGE_WRITE_IMPLEMENTATION})
+#     message(STATUS "stb_image_write is not enabled.")
+# endif()

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,11 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+cmake_minimum_required(VERSION 3.12)
+project(lib_stbiw LANGUAGES CXX)
+
+add_library(stbiw SHARED stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# `add_definitions`添加宏定义到当前目录和子目录下的所有源文件中, 但是不会对外部的源文件产生影响
+# add_definitions(-DSTB_IMAGE_WRITE_IMPLEMENTATION=1)
+
+# 设置为 private, 避免宏被传播到所有引用它的文件中, 而导致的重定义错误
+target_compile_definitions(stbiw PRIVATE -DSTB_IMAGE_WRITE_IMPLEMENTATION=1)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,1 @@
+#include "stb_image_write.h"

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,1 +1,3 @@
 #include "stb_image_write.h"
+
+int stbi_write_png(char const *filename, int w, int h, int comp, const void *data, int stride_in_bytes);


### PR DESCRIPTION
感谢小彭老师的课程，这是我完成的作业1。

我发现了下面这几个问题：

- 为什么使用`add_definitions` 通过了？因为`add_definitions` 给当前目录下和所有添加的子目录都添加一个`DEFINITION` ，而不会给包含它的上级目录添加，相当于是默认的`PRIVATE` 。
- 为什使用`target_compile_definitions(stbiw PUBLIC -DSTB_IMAGE_WRITE_IMPLEMENTATION=1)` 不通过？因为`mandel.h` 和`rainbow.h` 都include了stbiw库，所以如果在CMakeLists.txt中设置宏，会导致这个宏被定义了两次，发生冲突。如果在某个源文件中定义这个宏，由于头文件使用`#ifdef INCLUDE_STB_IMAGE_WRITE_H` 来标志函数实现的源码只被包含一次，所以不会发生冲突。应该在CMakeLists.txt文件中将宏设置为`PRIVATE` ，这样这个宏就不会传递到包含它的项目中，从而避免了重定义。
- 能否只使用头文件来进行编译，而不要再额外增加一个cpp文件？**可行**，因为头文件在预处理阶段就被复制到了引用它的源文件中，也就是它不会存在于编译阶段，也就不能拿来编译。其它的头文件库，例如[type_safe](https://github.com/foonathan/type_safe/blob/main/CMakeLists.txt#L94)中用的就是`INTERFACE` 关键字。由于`STB_IMAGE`里用的是`#ifdef`而不是`#ifndef`，不能只修改CMakeLists.txt而不修改某一个cpp源文件，因此[pull/14](https://github.com/parallel101/hw01/pull/14)只能去修改`main.cpp`，不符合要求。