### PR TITLE
add stbiw library

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,5 @@
+#define  STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
 #include "rainbow.h"
 #include "mandel.h"
 

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,2 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw INTERFACE)
+target_include_directories(stbiw INTERFACE .)


### PR DESCRIPTION
## 增加 head-only 库
将 stbiw 这个头文件库作为 interface 进行继承。这是一篇[介绍CMake继承机制](https://leimao.github.io/blog/CMake-Public-Private-Interface/)的文章。我仅在 main.cpp 文件中定义 STB_IMAGE_WRITE_IMPLEMENTATION 宏，让 stbi 系列函数的实现唯一。