### PR TITLE
添加 stbiw 库

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,7 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+#message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+cmake_minimum_required(VERSION 3.12)
+project(stbiw LANGUAGES CXX)
+
+add_library(stbiw STATIC stb_image_write.cpp stb_image_write.h)
+
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>


### PR DESCRIPTION
关于stbi 宏定义设计：
这是一种heard only 的设计方式。用IMPLEMENTATION宏来控制是否导入函数的定义。
没有定义IMPLEMENTATION宏时，导入stbi头文件，只有函数的声明。

我们只在stbiw的stb_image_write.cpp中,导入IMPLEMENTATION宏，以启用stbi函数的定义。
``` C++
#define STB_IMAGE_WRITE_IMPLEMENTATION
#include <stb_image_write.h>
``` 
然后将stbiw编译成一个静态库
```  CMake
add_library(stbiw STATIC stb_image_write.cpp stb_image_write.h)
target_include_directories(stbiw PUBLIC .)
``` 
其他项目通过add_subdirectory就可以使用stbiw库了