### PR TITLE
xiao-ming-hub 完成了作孽！

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+#message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>


### PR DESCRIPTION
  它用宏分离定义和实现的做法很妙。未定义 `STB_IMAGE_WRITE_IMPLEMENTATION` 时（如 mandel.cpp 和 rainbow.cpp），拿到的只有函数的定义。如果要生成用于编译时链接的库，写一个定义了这个宏、包含 stb_image_write.h 的 stb_image_write.cpp 文件就好，这样子这个 cpp 就能直接被编译成连接库了。（第一种做法）

  之所以 README.md 中“采分点提示”的做法不可行，是因为它第二个参数是 `PUBLIC`，所以改成 `PRIVATE` 就好，同时上面提到的 cpp 里的宏定义可以去掉，这样它只剩下包含指令了，而这个 cpp 的作用几乎与 stb_image_write.h 无异。（第二种做法）

  但它们还是有区别的，区别在于文件后缀不同。我尝试过有定义宏时直接编译，但 CMake 不能知道用什么语言编译，于是报错。
```
CMake Error: Cannot determine link language for target "stbiw".
CMake Error: CMake can not determine linker language for target: stbiw
```
也许可以某种指令强行指定编译语言来解决这个问题，但这是我第一次用 CMake，不想弄太复杂。我想到的解决方法是把 stb_image_write.h 重命名为 stb_image_write.cpp，同时更改 mandel.cpp 和 rainbow.cpp 的`#include` 内容。但这种做法需要改动 stbiw/ 之外的代码，所以这种做法没有前两种优。（第三种做法）