### PR TITLE
hw01 done

### DIFF
--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.cpp)
+
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,3 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+
+#include "stb_image_write.h"


### PR DESCRIPTION
1.header文件无法直接编译成库，在cpp文件中include，再生成libstbiw.a
2.为了可以直接include子文件的header文件，使用target_include_directories
PS.只实现了基础的要求，阅读其他同学作业获得了很多收获