### PR TITLE
第一次作业

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,5 @@ endif()
 add_subdirectory(stbiw)
 
 add_executable(main main.cpp rainbow.cpp mandel.cpp)
+# add_executable(main main.cpp rainbow.cpp)
 target_link_libraries(main PUBLIC stbiw)

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,3 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+add_library(stbiw STATIC stb_image_write.h stb_image_write.cpp)
+target_include_directories(stbiw PUBLIC .)

--- a/stbiw/stb_image_write.cpp
+++ b/stbiw/stb_image_write.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"

--- a/stbiw/stb_image_write.h
+++ b/stbiw/stb_image_write.h
@@ -147,7 +147,7 @@ LICENSE
   See end of file for license information.
 
 */
-
+#pragma once
 #ifndef INCLUDE_STB_IMAGE_WRITE_H
 #define INCLUDE_STB_IMAGE_WRITE_H
 


### PR DESCRIPTION
stbi为什么使用了 `STB_IMAGE_WRITE_IMPLEMENTATION` 和'INCLUDE_STB_IMAGE_WRITE_H'这两个宏进行条件编译？我个人理解，这是一种“解耦”的设计，提高编译速度、减少可执行文件大小----试想一下，如果不通过宏控制函数定义，每个#include  <stb_image_write.h>都要编译一遍（虽然函数是static的，可重复定义），每个都要编译一遍，会增加编译时间，同时增加可执行文件的体积。这个有些像是PIMPL的思想。


其他的，就是根据小彭老师课程内容，完成的常规的操作。