### PR TITLE
[CMake_Config] hw01 作业: 完成了 stbiw 目录下的 CMake 配置

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cmake.sourceDirectory": "D:/hw01-main"
+}

--- a/stbiw/CMakeLists.txt
+++ b/stbiw/CMakeLists.txt
@@ -1,1 +1,6 @@
-message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+# message(FATAL_ERROR "请修改 stbiw/CMakeLists.txt！要求生成一个名为 stbiw 的库")
+
+set(SOURCES stb_config.cpp)
+
+add_library(stbiw ${SOURCES})
+target_include_directories(stbiw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/stbiw/stb_config.cpp
+++ b/stbiw/stb_config.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"


### PR DESCRIPTION
为了回应作业要求，简单看了下与 stb 以及设计原则相关的两个仓库，发现仓库的设计相当有趣。在 cmake 的构建过程中，通过 自己定义 stbw/stbw_config.cpp 文件，将 .h 文件通过宏命令静态切换为实现版本，再生成对应的静态/动态链接库（可以发现 build/stbw/ 目录下的 libstbw.a 文件）。最后，通过 cmake 来链接起项目中源文件，实现了 .h 单文件中接口声明与实现的分离（cpp程序只需要 include 接口版本，链接实现版本生成的链接库）。

我想了想，这样做的好处在于：
1. 项目文件简洁：虽然按照传统的 头文件声明-cpp文件实现 的策略一样可以达成这接口-实现的分离，但是文件多起来难免看起来不那么简洁优雅。
2. 取消文件依赖关系：单个头文件中完成接口和实现，用宏命令分隔，cpp 文件仅起定义用户配置的作用，取消了项目文件之间的依赖关系，使用不易出错。

坏处可能是：
1. 不便于分发，对于开源库来说这个倒是可以容忍；对于不便于公开源代码的项目来说，这个构建策略是不可行的。
2. 宏命令不直观（可能），对于用户来说，通过定义宏命令来调整源码的实现方式，这个思路可能只适合熟悉 cmake/C++ 的开发者。

参考列表
1. https://github.com/nothings/stb
3. https://github.com/nothings/single_file_libs
4. 自己 cmake 生成的 build 目录